### PR TITLE
Noah : 학습용 체크리스트, 업무용 체크리스트 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,23 @@
 # swift-photoframe
 1주차 사진액자 프로젝트
 
-## 학습 계획
+## 학습용 체크리스트
 
 <img src="https://user-images.githubusercontent.com/63908856/223042897-e4073356-dd9f-4704-89d8-690e5c36cd51.png">
 
+**step 1-1**
 - [ ] iOS 프로젝트 그룹/타깃에 관해 학습
-- [ ] [ViewController Programming Guide](https://developer.apple.com/library/archive/featuredarticles/ViewControllerPGforiPhoneOS/index.html#//apple_ref/doc/uid/TP40007457-CH2-SW1) 학습
+- [ ] [Displaying and managing views with a view controller](https://developer.apple.com/documentation/uikit/view_controllers/displaying_and_managing_views_with_a_view_controller) 학습
+- [ ] [뷰 컨트롤러 생명주기](https://developer.apple.com/documentation/uikit/uiviewcontroller) 학습
+- [ ] UITabBarController, UITabBar 학습
 - [ ] [UIKit View Management](https://developer.apple.com/documentation/uikit/view_controllers) 클래스 학습
+
+**next step**
+- [ ] [ViewController Programming Guide](https://developer.apple.com/library/archive/featuredarticles/ViewControllerPGforiPhoneOS/index.html#//apple_ref/doc/uid/TP40007457-CH2-SW1) 학습
 - [ ] [IBOutlet, IBAction](https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/Outlets/Outlets.html#//apple_ref/doc/uid/TP40010810-CH10-SW1) 학습
 - [ ] [Receptionist Pattern](https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/ReceptionistPattern/ReceptionistPattern.html#//apple_ref/doc/uid/TP40010810-CH13-SW1) 학습
 - [ ] [Target-Action](https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/Target-Action/Target-Action.html#//apple_ref/doc/uid/TP40010810-CH12-SW1) 학습
 - [ ] Scene, Segue 동작 방식 학습
-- [ ] [뷰 컨트롤러 생명주기](https://developer.apple.com/documentation/uikit/uiviewcontroller) 학습
 - [ ] [뷰 컨트롤러 컨테이너](https://developer.apple.com/documentation/uikit/view_controllers/creating_a_custom_container_view_controller) 학습
 - [ ] 앱 번들 리소스 학습
 - [ ] [ImagePickerController](https://developer.apple.com/documentation/uikit/uiimagepickercontrollerdelegate/1619126-imagepickercontroller) 학습

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 <img src="https://user-images.githubusercontent.com/63908856/223042897-e4073356-dd9f-4704-89d8-690e5c36cd51.png">
 
-**step 1-1**
+**step 1-1** 
+DUE-DATE: 2023-03-08
 - [ ] iOS 프로젝트 그룹/타깃에 관해 학습
 - [ ] [Displaying and managing views with a view controller](https://developer.apple.com/documentation/uikit/view_controllers/displaying_and_managing_views_with_a_view_controller) 학습
 - [ ] [뷰 컨트롤러 생명주기](https://developer.apple.com/documentation/uikit/uiviewcontroller) 학습
@@ -13,6 +14,7 @@
 - [ ] [UIKit View Management](https://developer.apple.com/documentation/uikit/view_controllers) 클래스 학습
 
 **next step**
+DUE-DATE: 2023-03-10
 - [ ] [ViewController Programming Guide](https://developer.apple.com/library/archive/featuredarticles/ViewControllerPGforiPhoneOS/index.html#//apple_ref/doc/uid/TP40007457-CH2-SW1) 학습
 - [ ] [IBOutlet, IBAction](https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/Outlets/Outlets.html#//apple_ref/doc/uid/TP40010810-CH10-SW1) 학습
 - [ ] [Receptionist Pattern](https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/ReceptionistPattern/ReceptionistPattern.html#//apple_ref/doc/uid/TP40010810-CH13-SW1) 학습
@@ -24,6 +26,7 @@
 
 ## 업무용 체크리스트
 **step 1-1**
+DUE-DATE: 2023-03-08
 - [ ] iOS 프로젝트 생성 w/ App template
     - [ ] .gitignore 추가
     - [ ] Storyboard interface 설정

--- a/README.md
+++ b/README.md
@@ -16,3 +16,20 @@
 - [ ] [뷰 컨트롤러 컨테이너](https://developer.apple.com/documentation/uikit/view_controllers/creating_a_custom_container_view_controller) 학습
 - [ ] 앱 번들 리소스 학습
 - [ ] [ImagePickerController](https://developer.apple.com/documentation/uikit/uiimagepickercontrollerdelegate/1619126-imagepickercontroller) 학습
+
+## 업무용 체크리스트
+**step 1-1**
+- [ ] iOS 프로젝트 생성 w/ App template
+    - [ ] .gitignore 추가
+    - [ ] Storyboard interface 설정
+    - [ ] 나의 의도가 들어가지 않은 주석, 파일 삭제
+- [ ] TabBarController 추가
+    - [ ] InitialController 지정
+    - [ ] Scene 추가
+    - [ ] TabBarController Tab 갯수 2개로 지정
+    - [ ] TabBarController Tab Scene 지정
+- [ ] UIViewController 추가
+    - [ ] Scene의 Custom Class가 될 UIViewController를 상속받는 클래스 생성
+    - [ ] Storyboard ViewController Scene Custom Class 지정
+- [ ] viewDidLoad() 코드 추가
+    - [ ] #file, #line, #function, #column 코드 추가


### PR DESCRIPTION
- 지난번 [리뷰주신 내용](https://github.com/codesquad-members-2023/swift-photoframe/pull/9#pullrequestreview-1325671244)을 바탕으로 학습용 체크리스트와 업무용 체크리스트를 분리하였습니다.
- Step 1-1을 작게 나누어 체크리스트 업무 하나가 커밋 하나가 될 수 있도록 체크리스트를 구성하였습니다.